### PR TITLE
feat: replace retry sdk v1 with sdk v2 [CORE-310]

### DIFF
--- a/src/main/java/software/amazon/msk/auth/iam/CompatibilityHelper.java
+++ b/src/main/java/software/amazon/msk/auth/iam/CompatibilityHelper.java
@@ -1,0 +1,23 @@
+package software.amazon.msk.auth.iam;
+
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.exception.SdkException;
+
+public class CompatibilityHelper {
+
+  /**
+   * Convert an exception to an SdkException
+   *
+   * @param e Exception to convert
+   * @return SdkException
+   */
+  public static SdkException toSdkException(Exception e) {
+    if (e instanceof com.amazonaws.SdkClientException) {
+      return SdkClientException.create(e.getMessage(), e.getCause());
+    } else if (e instanceof SdkException) {
+      return (SdkException) e;
+    } else {
+      return SdkException.create(e.getMessage(), e);
+    }
+  }
+}


### PR DESCRIPTION
### What does it do? Why?

Trying to replace usage of java-sdk-v1 with api from java-sdk-v2, there is a lot of work, but starting somewhere.

Some code is here for compatibility issues waiting for next PRs